### PR TITLE
Fix GpugNode interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@ Created with Create GPUI App.
 - [`gpui`](https://www.gpui.rs/)
 - [GPUI documentation](https://github.com/zed-industries/zed/tree/main/crates/gpui/docs)
 - [GPUI examples](https://github.com/zed-industries/zed/tree/main/crates/gpui/examples)
+- [GPUI book](https://matinaniss.github.io/gpui-book/introduction.html)
+- [GPUI HN threads](https://duckduckgo.com/?t=ffab&q=%22gpui%22%20site%3Anews.ycombinator.com&ia=web)
+- [GPUI tutorial](https://github.com/hedge-ops/gpui-tutorial)
+- [GPUI component library](https://github.com/longbridge/gpui-component)
+- [GPUI music player](https://github.com/143mailliw/hummingbird)
+- [GPUI notes from me](https://studium.dev/tech/playing-gpui-rust)
 
 ## Usage
 
 - Ensure Rust is installed - [Rustup](https://rustup.rs/)
-- Run your app with `cargo run`
+- Run gpug with `cargo run`
+- Or run gpug with `cargo watch -q -c -w crates/gpug -x 'run -p gpug'`
+- To build gpug `cargo build --release`
 
 ## Demo
 


### PR DESCRIPTION
This PR fixes the issue where render updates weren't being propagated to the graph unless there was a node interaction. The bug existed due to variable name shadowing